### PR TITLE
Port to Proj 6.2.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use ExtUtils::MakeMaker;
+use Config;
                                                                                 
 require 5.006;
 
@@ -29,6 +30,9 @@ my $version = $1;
 $version ge $libversion
     or die "ERROR: libproj too old, found $version required is $libversion\n";
 
+my $projapiflags;
+$projapiflags = ' -DGEOPROJ4_PROJ_API=6' if $version ge '6.0.0';
+
 if($^O ne 'MSWin32' && $^O ne 'cygwin')
 {   unlink 'projects.h';
     my $own_projects = "src/$version/projects.h";
@@ -44,6 +48,7 @@ WriteMakefile
  , VERSION  => $relversion
  , AUTHOR   => 'Mark Overmeer'
  , ABSTRACT => 'Proj4 library for carthographic projections'
+ , CCFLAGS  => "$Config{ccflags}" . $projapiflags
  , INC      => "-I$FWTools/include -I."
  , LIBS     => [ "-L$FWTools/lib -lproj" ]
  , LICENSE  => 'perl_5'


### PR DESCRIPTION
Proj 6.2.0 depreacted some API and removed some (retrieving a list of
datums). This patch aims to make the XS code buildable with 6.2.0 as
well as with the previous Proj versions. The unaviable API is solved
by returning an empty list.

The code builds fine but some tests fail. Probably pj_fwd() changed
not only syntax (argument types), but also semantics. I have no
idea what proj did or should do. Any advice is welcome.

<https://github.com/markov2/perl5-Geo-Proj4/issues/1>
<https://github.com/markov2/perl5-Geo-Proj4/issues/3>